### PR TITLE
Per environment dataroot for phylogatr-web

### DIFF
--- a/charts-private/phylogatr-web/Chart.yaml
+++ b/charts-private/phylogatr-web/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: phylogatr-web
 description: OSC phylogatr web service
 type: application
-version: 0.13.0
+version: 0.14.0
 appVersion: "0.1.0"
 maintainers:
   - name: treydock

--- a/charts-private/phylogatr-web/values.yaml
+++ b/charts-private/phylogatr-web/values.yaml
@@ -6,6 +6,7 @@ global:
     production:
       serviceAccount: phylogatr
       dbPath: /fs/project/PAS1604/db/production/phylogatr.sqlite3
+      dataroot: /fs/project/PAS1604/pipeline/latest
       image:
         tag: '{{ .Values.global.imageTag }}'
       auth:
@@ -13,6 +14,7 @@ global:
     test:
       serviceAccount: phylogatr
       dbPath: /fs/project/PAS1604/db/production/phylogatr.sqlite3
+      dataroot: /fs/project/PAS1604/pipeline/latest
       image:
         tag: '{{ .Values.global.imageTag }}'
       auth:
@@ -20,6 +22,7 @@ global:
     dev:
       serviceAccount: phylogatrdev
       dbPath: /fs/project/PAS1604/db/dev/phylogatr.sqlite3
+      dataroot: /fs/project/PAS1604/pipeline/dev
       image:
         tag: latest
       auth:
@@ -48,11 +51,11 @@ webservice:
   - name: BATCH_MODE
     value: '1'
   - name: OOD_DATAROOT
-    value: /fs/project/PAS1604/pipeline/latest
+    value: '{{ index .Values.global.env (include "osc.common.environment" .) "dataroot" }}'
   - name: GENES_TARBALL_PATH
-    value: /fs/project/PAS1604/pipeline/latest/genes.tar.gz
+    value: '{{ index .Values.global.env (include "osc.common.environment" .) "dataroot" }}/genes.tar.gz'
   - name: SIF_PATH
-    value: /fs/project/PAS1604/pipeline/latest/phylogatr.sif
+    value: '{{ index .Values.global.env (include "osc.common.environment" .) "dataroot" }}/phylogatr.sif'
   - name: REAL_DATABASE_URL
     value: 'sqlite3://{{ index .Values.global.env (include "osc.common.environment" .) "dbPath" }}'
   image:


### PR DESCRIPTION
Fixes #103

@johrstrom Doing local render, this is what I get with test:

```
        - name: OOD_DATAROOT
          value: "/fs/project/PAS1604/pipeline/latest"
        - name: GENES_TARBALL_PATH
          value: "/fs/project/PAS1604/pipeline/latest/genes.tar.gz"
        - name: SIF_PATH
          value: "/fs/project/PAS1604/pipeline/latest/phylogatr.sif"
```

This is dev:

```
        - name: OOD_DATAROOT
          value: "/fs/project/PAS1604/pipeline/dev"
        - name: GENES_TARBALL_PATH
          value: "/fs/project/PAS1604/pipeline/dev/genes.tar.gz"
        - name: SIF_PATH
          value: "/fs/project/PAS1604/pipeline/dev/phylogatr.sif"
```