### PR TITLE
Fix Ingress TLS handling to avoid errors with cert-manager

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kyverno-policies
 description: OSC Kyverno policies deployment
 type: application
-version: 0.13.1
+version: 0.14.0
 appVersion: "v1.6.1"
 maintainers:
   - name: treydock

--- a/charts/kyverno-policies/templates/ingress-require-tls.yaml
+++ b/charts/kyverno-policies/templates/ingress-require-tls.yaml
@@ -17,6 +17,10 @@ spec:
       any:
         - resources:
             name: "cm-acme-http-solver-*"
+        - resources:
+            annotations:
+              nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+              nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
     validate:
       message: "Ingress is required to have TLS."
       pattern:

--- a/charts/webservice/Chart.yaml
+++ b/charts/webservice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: webservice
 description: OSC webservice bootstrap Helm Chart
 type: application
-version: 0.16.0
+version: 0.17.0
 appVersion: "0.1.0"
 maintainers:
   - name: treydock

--- a/charts/webservice/templates/auth-ingress.yaml
+++ b/charts/webservice/templates/auth-ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "webservice.auth.labels" . | nindent 4 }}
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -22,7 +23,7 @@ spec:
   {{- if (include "webservice.ingressHostAlias" .) }}
     - {{ tpl (include "webservice.ingressHostAlias" .) . | quote }}
   {{- end }}
-    secretName: {{ include "webservice.name" . }}-cert
+    secretName: {{ include "webservice.auth.name" . }}-cert
   rules:
   - host: {{ tpl (include "webservice.ingressHost" .) . | quote }}
     http:

--- a/charts/webservice/templates/ingress.yaml
+++ b/charts/webservice/templates/ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "webservice.labels" . | nindent 4 }}
   annotations:
+    {{- if not .Values.auth.enable }}
+    cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -19,6 +22,7 @@ metadata:
       {{- toYaml .Values.ingress.rShinyAnnotations | nindent 4 }}
     {{- end }}
 spec:
+{{- if not .Values.auth.enable }}
   tls:
   - hosts:
     - {{ required "Must provide ingress host" (tpl (include "webservice.ingressHost" .) .) | quote }}
@@ -26,6 +30,7 @@ spec:
     - {{ tpl (include "webservice.ingressHostAlias" .) . | quote }}
   {{- end }}
     secretName: {{ include "webservice.name" . }}-cert
+{{- end }}
   rules:
   - host: {{ tpl (include "webservice.ingressHost" .) . | quote }}
     http:

--- a/charts/webservice/values.yaml
+++ b/charts/webservice/values.yaml
@@ -106,7 +106,6 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
-    cert-manager.io/cluster-issuer: letsencrypt
   rShinyAnnotations:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"

--- a/tests/kyverno-policies/ingress-require-tls/resources.yaml
+++ b/tests/kyverno-policies/ingress-require-tls/resources.yaml
@@ -24,6 +24,30 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: skip-oauth2
+  namespace: test
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+  labels:
+    app: web
+spec:
+  rules:
+  - host: web.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
   name: test-pass
   namespace: test
   annotations:

--- a/tests/kyverno-policies/ingress-require-tls/test.yaml
+++ b/tests/kyverno-policies/ingress-require-tls/test.yaml
@@ -12,6 +12,11 @@ results:
     result: skip
   - policy: ingress-require-tls
     rule: require-tls
+    resource: skip-oauth2
+    kind: Ingress
+    result: skip
+  - policy: ingress-require-tls
+    rule: require-tls
     resource: test-pass
     kind: Ingress
     result: pass


### PR DESCRIPTION
Only manage SSL cert on auth if auth is enabled, to avoid situation where duplicate secrets are causing cert-manager to reject renewal

Do not require TLS defined when using oauth2 redirect