### PR TITLE
Prometheus chart updates

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: prometheus
 description: OSC Prometheus deployment
 type: application
-version: 0.15.3
-appVersion: "v2.35.0"
+version: 0.16.0
+appVersion: "v2.44.0"
 maintainers:
   - name: treydock
 dependencies:
   - name: kube-state-metrics
-    version: 4.7.0
+    version: 5.6.2
     repository: https://prometheus-community.github.io/helm-charts/
   - name: dcgm-exporter
     version: 2.6.5

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -100,7 +100,7 @@ proxy:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
     pullPolicy: IfNotPresent
-    tag: "v7.1.3"
+    tag: "v7.4.0"
   securityContext: {}
   resources: {}
   service:
@@ -132,7 +132,7 @@ blackboxExporter:
   image:
     repository: docker.io/prom/blackbox-exporter
     pullPolicy: IfNotPresent
-    tag: "v0.20.0"
+    tag: "v0.24.0"
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -169,7 +169,7 @@ sslExporter:
   image:
     repository: docker.io/ribbybibby/ssl-exporter
     pullPolicy: IfNotPresent
-    tag: "2.4.1"
+    tag: "2.4.2"
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:


### PR DESCRIPTION
* Update Prometheus to v2.44.0
* Update kube-state-metrics chart to 5.6.2
* Update oauth2-proxy to v7.4.0
* Update black-exporter to v0.24.0
* Update ssl-exporter to 2.4.2