### PR TITLE
Do not scan images in background

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kyverno-policies
 description: OSC Kyverno policies deployment
 type: application
-version: 0.21.1
+version: 0.21.2
 appVersion: "v1.8.5"
 maintainers:
   - name: treydock

--- a/charts/kyverno-policies/templates/block-images-with-volumes.yaml
+++ b/charts/kyverno-policies/templates/block-images-with-volumes.yaml
@@ -16,9 +16,11 @@ metadata:
       This may be unexpected and undesirable. This policy checks the contents of every
       container image and inspects them for such VOLUME statements, then blocks if found.      
 spec:
-  validationFailureAction: {{ index .Values.validationFailureAction "block-images-with-volumes" | default "enforce" }}
+  validationFailureAction: enforce
   failurePolicy: Ignore
-  background: true
+  # TODO: Re-enable once on Kyverno 1.9+ and can ensure background scan interval is longer
+  # This background scan was spamming Harbor at OSC
+  background: false
   rules:
   - name: block-images-with-vols
     match:


### PR DESCRIPTION
This was spamming Harbor
Also failurePolicy now ignores so no need to flip enforcement of image scans