### PR TITLE
Update for how Prometheus labels things and alerts

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus
 description: OSC Prometheus deployment
 type: application
-version: 0.17.0
+version: 0.18.0
 appVersion: "v2.44.0"
 maintainers:
   - name: treydock

--- a/charts/prometheus/templates/config.yaml
+++ b/charts/prometheus/templates/config.yaml
@@ -136,7 +136,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_service_name]
         target_label: kubernetes_name
       - regex: "app_kubernetes_io_(managed_by|version)"
@@ -165,7 +165,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_service_name]
         target_label: kubernetes_name
       - source_labels: [kubernetes_name,__meta_kubernetes_service_port_name]
@@ -212,7 +212,7 @@ data:
       - source_labels: [host]
         target_label: node
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: kubernetes_name
       - source_labels: [kubernetes_name,__meta_kubernetes_pod_annotation_prometheus_io_port]
@@ -256,7 +256,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_ingress_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_ingress_name]
         target_label: kubernetes_name
       - regex: "app_kubernetes_io_(managed_by|version)"
@@ -292,7 +292,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_ingress_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_ingress_name]
         target_label: kubernetes_name
       - regex: "app_kubernetes_io_(managed_by|version)"

--- a/charts/webservice/Chart.yaml
+++ b/charts/webservice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: webservice
 description: OSC webservice bootstrap Helm Chart
 type: application
-version: 0.30.0
+version: 0.31.0
 appVersion: "0.1.0"
 maintainers:
   - name: treydock

--- a/charts/webservice/templates/_helpers.tpl
+++ b/charts/webservice/templates/_helpers.tpl
@@ -164,7 +164,7 @@ app.kubernetes.io/name: {{ printf "%s-auth" (include "webservice.name" .) }}
   {{- if and (index .Values.global.env (include "osc.common.environment" .)) }}
     {{- if (index .Values.global.env (include "osc.common.environment" .) "service") }}
       {{- if (index .Values.global.env (include "osc.common.environment" .) "service" "alert") }}
-        {{- index .Values.global.env (include "osc.common.environment" .) "service" "alert" "receiver" }}
+        {{ index .Values.global.env (include "osc.common.environment" .) "service" "alert" "receiver" }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/webservice/templates/auth-deployment.yaml
+++ b/charts/webservice/templates/auth-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{ include "osc.common.serviceAccount" . }}
     {{- include "webservice.auth.labels" . | nindent 4 }}
+  {{- if (include "webservice.alert.receiver" .) }}
+    receiver: {{ include "webservice.alert.receiver" . }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -21,6 +24,9 @@ spec:
       labels:
         {{ include "osc.common.serviceAccount" . }}
         {{- include "webservice.auth.selectorLabels" . | nindent 8 }}
+      {{- if (include "webservice.alert.receiver" .) }}
+        receiver: {{ include "webservice.alert.receiver" . }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "webservice.name" . }}
       securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/webservice/templates/auth-ingress.yaml
+++ b/charts/webservice/templates/auth-ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "webservice.auth.name" . }}
   labels:
     {{- include "webservice.auth.labels" . | nindent 4 }}
+  {{- if (include "webservice.alert.receiver" .) }}
+    receiver: {{ include "webservice.alert.receiver" . }}
+  {{- end }}
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
     {{- with .Values.ingress.annotations }}

--- a/charts/webservice/templates/auth-service.yaml
+++ b/charts/webservice/templates/auth-service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "webservice.auth.name" . }}
   labels:
     {{- include "webservice.auth.labels" . | nindent 4 }}
+  {{- if (include "webservice.alert.receiver" .) }}
+    receiver: {{ include "webservice.alert.receiver" . }}
+  {{- end }}
   {{- with .Values.auth.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/webservice/templates/deployment.yaml
+++ b/charts/webservice/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{ include "osc.common.serviceAccount" . }}
     {{- include "webservice.labels" . | nindent 4 }}
+  {{- if (include "webservice.alert.receiver" .) }}
+    receiver: {{ include "webservice.alert.receiver" . }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -20,6 +23,9 @@ spec:
       labels:
         {{ include "osc.common.serviceAccount" . }}
         {{- include "webservice.selectorLabels" . | nindent 8 }}
+      {{- if (include "webservice.alert.receiver" .) }}
+        receiver: {{ include "webservice.alert.receiver" . }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "webservice.name" . }}
       securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/webservice/templates/ingress.yaml
+++ b/charts/webservice/templates/ingress.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "webservice.name" . }}
   labels:
     {{- include "webservice.labels" . | nindent 4 }}
+  {{- if (include "webservice.alert.receiver" .) }}
+    receiver: {{ include "webservice.alert.receiver" . }}
+  {{- end }}
   annotations:
     {{- if .Values.auth.enable }}
     prometheus.io/probe_scheme: 'https'


### PR DESCRIPTION
Replace kubernetes_namespace label with just namespace so uniform across all Kubernetes metrics Add "receiver" label to more resources in webservices to ensure folks can get notified when things break