### PR TITLE
Rely on annotations for PVC service-account logic

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kyverno-policies
 description: OSC Kyverno policies deployment
 type: application
-version: 0.33.1
+version: 0.34.0
 appVersion: "v1.13.2"
 maintainers:
   - name: treydock

--- a/charts/kyverno-policies/templates/add-pvc-service-account.yaml
+++ b/charts/kyverno-policies/templates/add-pvc-service-account.yaml
@@ -28,7 +28,7 @@ spec:
     context:
       - name: serviceAccount
         variable:
-          jmesPath: request.object.metadata.labels."{{ include "osc.common.serviceAccountKey" . }}"
+          jmesPath: request.object.metadata.annotations."{{ include "osc.common.serviceAccountKey" . }}"
           default: ''
       - name: uidMap
         configMap:
@@ -41,7 +41,7 @@ spec:
     mutate:
       patchStrategicMerge:
         metadata:
-          labels:
+          annotations:
             osc.edu/service-account: "{{`{{ serviceAccount }}`}}"
             osc.edu/service-account-uid: "{{`{{`}} uidMap.data.\"user-{{`{{`}} serviceAccount {{`}}`}}\" {{`}}`}}"
             osc.edu/service-account-gid: "{{`{{`}} gidMap.data.\"user-{{`{{`}} serviceAccount {{`}}`}}\" {{`}}`}}"
@@ -80,7 +80,7 @@ spec:
     mutate:
       patchStrategicMerge:
         metadata:
-          labels:
+          annotations:
             osc.edu/service-account: "{{`{{ serviceAccount }}`}}"
             osc.edu/service-account-uid: "{{`{{`}} uidMap.data.\"user-{{`{{`}} serviceAccount {{`}}`}}\" {{`}}`}}"
             osc.edu/service-account-gid: "{{`{{`}} gidMap.data.\"user-{{`{{`}} serviceAccount {{`}}`}}\" {{`}}`}}"

--- a/charts/kyverno-policies/templates/add-statefulset-service-account.yaml
+++ b/charts/kyverno-policies/templates/add-statefulset-service-account.yaml
@@ -28,7 +28,7 @@ spec:
     context:
       - name: serviceAccount
         variable:
-          jmesPath: request.object.metadata.labels."{{ include "osc.common.serviceAccountKey" . }}"
+          jmesPath: request.object.metadata.annotations."{{ include "osc.common.serviceAccountKey" . }}"
           default: ''
       - name: uidMap
         configMap:
@@ -42,13 +42,13 @@ spec:
       foreach:
         - list: "request.object.spec.volumeClaimTemplates[]"
           patchesJson6902: |-
-            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/labels/osc.edu~1service-account
+            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/annotations/osc.edu~1service-account
               op: add
               value: {{`{{ serviceAccount }}`}}
-            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/labels/osc.edu~1service-account-uid
+            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/annotations/osc.edu~1service-account-uid
               op: add
               value: '{{`{{`}} uidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
-            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/labels/osc.edu~1service-account-gid
+            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/annotations/osc.edu~1service-account-gid
               op: add
               value: '{{`{{`}} gidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
   - name: statefulset-add-service-account-paas
@@ -87,12 +87,12 @@ spec:
       foreach:
         - list: "request.object.spec.volumeClaimTemplates[]"
           patchesJson6902: |-
-            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/labels/osc.edu~1service-account
+            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/annotations/osc.edu~1service-account
               op: add
               value: {{`{{ serviceAccount }}`}}
-            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/labels/osc.edu~1service-account-uid
+            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/annotations/osc.edu~1service-account-uid
               op: add
               value: '{{`{{`}} uidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
-            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/labels/osc.edu~1service-account-gid
+            - path: /spec/volumeClaimTemplates/{{`{{elementIndex}}`}}/metadata/annotations/osc.edu~1service-account-gid
               op: add
               value: '{{`{{`}} gidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'

--- a/charts/kyverno-policies/templates/pvc-gpfs-fileset.yaml
+++ b/charts/kyverno-policies/templates/pvc-gpfs-fileset.yaml
@@ -35,10 +35,10 @@ spec:
           - local-ess
           - local-scratch
     validate:
-      message: "PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} label be set."
+      message: "PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} annotation to be set."
       pattern:
         metadata:
-          labels:
+          annotations:
             {{ include "osc.common.serviceAccountKey" . }}: "?*"
   - name: validate-service-account-uid-gid-webservice
     match:
@@ -62,7 +62,7 @@ spec:
     context:
       - name: serviceAccount
         variable:
-          jmesPath: request.object.metadata.labels."{{ include "osc.common.serviceAccountKey" . }}"
+          jmesPath: request.object.metadata.annotations."{{ include "osc.common.serviceAccountKey" . }}"
           default: ''
       - name: uidMap
         configMap:
@@ -73,10 +73,10 @@ spec:
           name: user-gid-map
           namespace: k8-ldap-configmap
     validate:
-      message: "PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} labels be set to the correct UID and GID."
+      message: "PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} annotations be set to the correct UID and GID."
       pattern:
         metadata:
-          labels:
+          annotations:
             osc.edu/service-account-uid: '{{`{{`}} uidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
             osc.edu/service-account-gid: '{{`{{`}} gidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
   - name: validate-service-account-uid-gid-paas
@@ -112,10 +112,10 @@ spec:
           name: user-gid-map
           namespace: k8-ldap-configmap
     validate:
-      message: "PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} labels be set to the correct UID and GID."
+      message: "PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} annotations be set to the correct UID and GID."
       pattern:
         metadata:
-          labels:
+          annotations:
             osc.edu/service-account: "{{`{{ serviceAccount }}`}}"
             osc.edu/service-account-uid: '{{`{{`}} uidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
             osc.edu/service-account-gid: '{{`{{`}} gidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
@@ -180,7 +180,7 @@ spec:
         conditions:
         - key: "{{`{{ request.object.metadata.annotations.\"osc.edu/fileset\" }}`}}"
           operator: AnyNotIn
-          value: "{{`{{ userGroupMap.data.\"user-{{ request.object.metadata.labels.\"osc.edu/service-account\" || '' }}\" }}`}}"
+          value: "{{`{{ userGroupMap.data.\"user-{{ request.object.metadata.annotations.\"osc.edu/service-account\" || '' }}\" }}`}}"
   - name: validate-paas-fileset-annotation
     match:
       any:

--- a/charts/kyverno-policies/templates/statefulset-gpfs-fileset.yaml
+++ b/charts/kyverno-policies/templates/statefulset-gpfs-fileset.yaml
@@ -35,14 +35,14 @@ spec:
           - local-ess
           - local-scratch
     validate:
-      message: "StatefulSet using PVC with local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} label be set."
+      message: "StatefulSet using PVC with local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} annotation be set."
       pattern:
         spec:
           =(volumeClaimTemplates):
             - (spec):
                 (storageClassName): "local-ess | local-scratch"
               metadata:
-                labels:
+                annotations:
                   {{ include "osc.common.serviceAccountKey" . }}: "?*"
   - name: validate-service-account-uid-gid-webservice
     match:
@@ -77,14 +77,14 @@ spec:
           name: user-gid-map
           namespace: k8-ldap-configmap
     validate:
-      message: "StatefulSet PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} labels be set to the correct UID and GID."
+      message: "StatefulSet PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} annotations be set to the correct UID and GID."
       pattern:
         spec:
           =(volumeClaimTemplates):
             - (spec):
                 (storageClassName): "local-ess | local-scratch"
               metadata:
-                labels:
+                annotations:
                   osc.edu/service-account-uid: '{{`{{`}} uidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
                   osc.edu/service-account-gid: '{{`{{`}} gidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
   - name: validate-service-account-uid-gid-paas
@@ -120,14 +120,14 @@ spec:
           name: user-gid-map
           namespace: k8-ldap-configmap
     validate:
-      message: "StatefulSet PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} labels be set to the correct UID and GID."
+      message: "StatefulSet PVC using local-ess or local-scratch requires {{ include "osc.common.serviceAccountKey" . }} annotations be set to the correct UID and GID."
       pattern:
         spec:
           =(volumeClaimTemplates):
             - (spec):
                 (storageClassName): "local-ess | local-scratch"
               metadata:
-                labels:
+                annotations:
                   osc.edu/service-account: "{{`{{ serviceAccount }}`}}"
                   osc.edu/service-account-uid: '{{`{{`}} uidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'
                   osc.edu/service-account-gid: '{{`{{`}} gidMap.data."user-{{`{{`}} serviceAccount {{`}}`}}" {{`}}`}}'

--- a/tests/kyverno-policies/add-pvc-service-account/pvc-paas-scratch.yaml
+++ b/tests/kyverno-policies/add-pvc-service-account/pvc-paas-scratch.yaml
@@ -4,11 +4,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-paas-scratch
   namespace: paas
-  labels:
+  annotations:
     osc.edu/service-account: test
     osc.edu/service-account-uid: '1000'
     osc.edu/service-account-gid: '1001'
-  annotations:
     osc.edu/fileset: user-test-fileset
 spec:
   accessModes:

--- a/tests/kyverno-policies/add-pvc-service-account/pvc-webservice-scratch.yaml
+++ b/tests/kyverno-policies/add-pvc-service-account/pvc-webservice-scratch.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: webservice
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
     osc.edu/service-account-uid: '1000'
     osc.edu/service-account-gid: '1001'

--- a/tests/kyverno-policies/add-pvc-service-account/resources.yaml
+++ b/tests/kyverno-policies/add-pvc-service-account/resources.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: webservice
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
 spec:
   accessModes:
@@ -23,7 +22,7 @@ metadata:
   namespace: webservice
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
+  annotations:
     osc.edu/service-account: test
 spec:
   accessModes:

--- a/tests/kyverno-policies/add-statefulset-service-account/paas-statefulset-patched.yaml
+++ b/tests/kyverno-policies/add-statefulset-service-account/paas-statefulset-patched.yaml
@@ -10,7 +10,6 @@ spec:
         name: paas-statefulset-pvc
         annotations:
           osc.edu/fileset: "test-fileset"
-        labels:
           osc.edu/service-account: "test-user"
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
@@ -28,7 +27,6 @@ spec:
         name: paas-statefulset-pvc
         annotations:
           osc.edu/fileset: "test-fileset"
-        labels:
           osc.edu/service-account: "test-user"
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"

--- a/tests/kyverno-policies/add-statefulset-service-account/resources.yaml
+++ b/tests/kyverno-policies/add-statefulset-service-account/resources.yaml
@@ -4,7 +4,7 @@ kind: StatefulSet
 metadata:
   name: webservice-statefulset
   namespace: webservice
-  labels:
+  annotations:
     osc.edu/service-account: "test-user"
 spec:
   volumeClaimTemplates:
@@ -20,7 +20,7 @@ kind: StatefulSet
 metadata:
   name: webservice-statefulset-ess
   namespace: webservice
-  labels:
+  annotations:
     osc.edu/service-account: "test-user"
 spec:
   volumeClaimTemplates:

--- a/tests/kyverno-policies/add-statefulset-service-account/webservice-statefulset-patched.yaml
+++ b/tests/kyverno-policies/add-statefulset-service-account/webservice-statefulset-patched.yaml
@@ -4,7 +4,7 @@ kind: StatefulSet
 metadata:
   name: webservice-statefulset
   namespace: webservice
-  labels:
+  annotations:
     osc.edu/service-account: "test-user"
 spec:
   volumeClaimTemplates:
@@ -12,7 +12,6 @@ spec:
         name: webservice-statefulset-pvc
         annotations:
           osc.edu/fileset: "test-fileset"
-        labels:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
@@ -24,7 +23,7 @@ kind: StatefulSet
 metadata:
   name: webservice-statefulset-ess
   namespace: webservice
-  labels:
+  annotations:
     osc.edu/service-account: "test-user"
 spec:
   volumeClaimTemplates:
@@ -32,7 +31,6 @@ spec:
         name: webservice-statefulset-pvc
         annotations:
           osc.edu/fileset: "test-fileset"
-        labels:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"

--- a/tests/kyverno-policies/pvc-gpfs-fileset/resources.yaml
+++ b/tests/kyverno-policies/pvc-gpfs-fileset/resources.yaml
@@ -18,7 +18,6 @@ metadata:
   namespace: webservice
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
 spec:
   accessModes:
@@ -76,9 +75,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-paas-pass
   namespace: paas
-  labels:
-    osc.edu/service-account: user-test
   annotations:
+    osc.edu/service-account: user-test
     osc.edu/fileset: user-test-fileset
 spec:
   accessModes:
@@ -192,7 +190,6 @@ metadata:
   namespace: webservice
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
     osc.edu/service-account-uid: "1000"
     osc.edu/service-account-gid: "1001"
@@ -211,7 +208,6 @@ metadata:
   namespace: webservice
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
     osc.edu/service-account-uid: "2000"
     osc.edu/service-account-gid: "2001"
@@ -230,7 +226,6 @@ metadata:
   namespace: webservice
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
 spec:
   accessModes:
@@ -247,7 +242,6 @@ metadata:
   namespace: webservice
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account-uid: "1000"
     osc.edu/service-account-gid: "1001"
 spec:
@@ -265,7 +259,6 @@ metadata:
   namespace: paas
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
     osc.edu/service-account-uid: "1000"
     osc.edu/service-account-gid: "1001"
@@ -284,7 +277,6 @@ metadata:
   namespace: paas
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
     osc.edu/service-account-uid: "2000"
     osc.edu/service-account-gid: "2001"
@@ -303,7 +295,6 @@ metadata:
   namespace: paas
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: test
 spec:
   accessModes:
@@ -320,7 +311,6 @@ metadata:
   namespace: paas
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account-uid: "1000"
     osc.edu/service-account-gid: "1001"
 spec:
@@ -338,7 +328,6 @@ metadata:
   namespace: paas
   annotations:
     osc.edu/fileset: user-test-fileset
-  labels:
     osc.edu/service-account: foo
     osc.edu/service-account-uid: "1000"
     osc.edu/service-account-gid: "1001"

--- a/tests/kyverno-policies/statefulset-gpfs-fileset/resources.yaml
+++ b/tests/kyverno-policies/statefulset-gpfs-fileset/resources.yaml
@@ -8,9 +8,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: webservice-statefulset-pvc
-        labels:
-          osc.edu/service-account: "test-user"
         annotations:
+          osc.edu/service-account: "test-user"
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -38,9 +37,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
-          osc.edu/service-account: "test-user"
         annotations:
+          osc.edu/service-account: "test-user"
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -180,11 +178,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: webservice-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -204,11 +201,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: webservice-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-scratch
@@ -228,11 +224,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: webservice-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "999"
           osc.edu/service-account-gid: "999"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -248,11 +243,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: webservice-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: foo
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-scratch
@@ -269,11 +263,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: webservice-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "999"
           osc.edu/service-account-gid: "999"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-scratch
@@ -321,11 +314,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -341,11 +333,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-scratch
@@ -361,11 +352,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: foo
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -381,11 +371,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "999"
           osc.edu/service-account-gid: "999"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -401,11 +390,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account: test-user
           osc.edu/service-account-uid: "999"
           osc.edu/service-account-gid: "999"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-scratch
@@ -421,10 +409,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
+        annotations:
           osc.edu/service-account-uid: "1000"
           osc.edu/service-account-gid: "1001"
-        annotations:
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -440,9 +427,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
-          osc.edu/service-account: test-user
         annotations:
+          osc.edu/service-account: test-user
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-ess
@@ -458,9 +444,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: paas-statefulset-pvc
-        labels:
-          osc.edu/service-account: test-user
         annotations:
+          osc.edu/service-account: test-user
           osc.edu/fileset: "test-fileset"
       spec:
         storageClassName: local-scratch


### PR DESCRIPTION
The annotations are for determining site-specific behavior and keeping them all in annotations vs some in labels offers consistency