### PR TITLE
Fix Keycloak auth setup

### DIFF
--- a/charts/cryosparc/Chart.yaml
+++ b/charts/cryosparc/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cryosparc
 description: OSC CryoSPARC bootstrap Helm Chart
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 maintainers:
   - name: zyou

--- a/charts/cryosparc/README.md
+++ b/charts/cryosparc/README.md
@@ -1,6 +1,6 @@
 # cryosparc
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 OSC CryoSPARC bootstrap Helm Chart
 
@@ -116,10 +116,10 @@ service:
 | ingress.className |  | `"nginx"` |
 | ingress.annotations."nginx.ingress.kubernetes.io/proxy-buffer-size" |  | `"16k"` |
 | ingress.annotations."nginx.ingress.kubernetes.io/ssl-redirect" |  | `"true"` |
-| auth.clientID | Keycloak client ID. Also pulled from global.auth.clientID | `"kubernetes-{{ include \"cryosparc.name\" . }}"` |
+| auth.clientID | Keycloak client ID. Also pulled from global.auth.clientID | `nil` |
 | auth.clientSecret | Keycloak client secret. Also pulled from global.auth.clientSecret | `nil` |
 | auth.cookieSecret | Keycloak cookie secret. Also pulled from global.auth.cookieSecret | `nil` |
-| auth.cookieName |  | `"_{{ tpl (include \"osc.common.serviceAccountValue\" .) . }}{{ include \"osc.common.environment\" . }}"` |
+| auth.cookieName |  | `"_{{ include \"cryosparc.name\" . }}{{ include \"osc.common.environment\" . }}"` |
 | auth.idpHost | Keycloak IDP host. Also pulled from global.auth.idpHost | `nil` |
 | auth.oidcIssuerURL |  | `"https://$(IDP_HOST)/realms/osc"` |
 | auth.allowGroupsBase | Base groups allowed to login | `["sappstf","sysstf","{{ .Values.project }}"]` |

--- a/charts/cryosparc/ci/test-values.yaml
+++ b/charts/cryosparc/ci/test-values.yaml
@@ -21,6 +21,7 @@ mounts:
 nodeSelector:
   kubernetes.io/os: linux
 auth:
+  clientID: test
   clientSecret: b8a873d4-e662-496c-ad43-26596eaff68c
   cookieSecret: PwRlaBzY3aBtKvshJzlMpxyfAp6AZg7orRoKz3NtuJw=
   oidcIssuerURL: http://keycloak.keycloak.svc.cluster.local/realms/master

--- a/charts/cryosparc/values.yaml
+++ b/charts/cryosparc/values.yaml
@@ -131,12 +131,12 @@ ingress:
 
 auth:
   # -- Keycloak client ID. Also pulled from global.auth.clientID
-  clientID: kubernetes-{{ include "cryosparc.name" . }}
+  clientID:
   # -- Keycloak client secret. Also pulled from global.auth.clientSecret
   clientSecret:
   # -- Keycloak cookie secret. Also pulled from global.auth.cookieSecret
   cookieSecret:
-  cookieName: _{{ tpl (include "osc.common.serviceAccountValue" .) . }}{{ include "osc.common.environment" . }}
+  cookieName: _{{ include "cryosparc.name" . }}{{ include "osc.common.environment" . }}
   # -- Keycloak IDP host. Also pulled from global.auth.idpHost
   idpHost:
   oidcIssuerURL: https://$(IDP_HOST)/realms/osc


### PR DESCRIPTION
The clientID needs to be unset so Puppet can set the global value