### PR TITLE
Ollama service used in the classroom backend

### DIFF
--- a/.github/workflows/test-private.yaml
+++ b/.github/workflows/test-private.yaml
@@ -24,6 +24,9 @@ jobs:
           python-version: 3.9
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.8.0
+      - name: Helm login
+        run: |
+          echo -n '${{ secrets.OSC_REGISTRY_ROBOT_OSC_READ_TOKEN }}' | helm registry login docker-registry.osc.edu -u '${{ secrets.OSC_REGISTRY_ROBOT_OSC_READ_USERNAME }}' --password-stdin
       - name: Run chart-testing (lint)
         run: ct lint --config .github/config/cf.yaml --chart-dirs charts-private
 
@@ -71,6 +74,9 @@ jobs:
         run: |
           kubectl label node kind-control-plane node-role.kubernetes.io/test=''
           kubectl label node kind-control-plane node-role.kubernetes.io/webservices=''
+      - name: Helm login
+        run: |
+          echo -n '${{ secrets.OSC_REGISTRY_ROBOT_OSC_READ_TOKEN }}' | helm registry login docker-registry.osc.edu -u '${{ secrets.OSC_REGISTRY_ROBOT_OSC_READ_USERNAME }}' --password-stdin
       - name: Build and Load nominatim images
         if: matrix.chart == 'nominatim'
         run: |

--- a/charts-private/ollama/Chart.yaml
+++ b/charts-private/ollama/Chart.yaml
@@ -14,5 +14,5 @@ dependencies:
   - name: ollama
     version: 1.54.0-osc-r2
     repository: oci://docker-registry.osc.edu/kubernetes/charts
-    #version: 1.54.0
-    #repository: file://./ollama-helm
+    # version: 1.54.0
+    # repository: file://./ollama-helm

--- a/charts-private/ollama/Chart.yaml
+++ b/charts-private/ollama/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: https://osc.github.io/osc-helm-charts/
     # repository: file://../../charts/osc-common
   - name: ollama
-    version: 1.54.0-osc-r1
-    repository: oci://docker-registry.osc.edu/kubernetes/charts
+    version: 1.54.0-osc-r2
+    #repository: oci://docker-registry.osc.edu/kubernetes/charts
     #version: 1.54.0
     #repository: file://./ollama-helm

--- a/charts-private/ollama/Chart.yaml
+++ b/charts-private/ollama/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ollama
 description: OSC Ollama service for classroom
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: '0.18.3'
 maintainers:
   - name: zyou
@@ -13,6 +13,6 @@ dependencies:
     # repository: file://../../charts/osc-common
   - name: ollama
     version: 1.54.0-osc-r2
-    #repository: oci://docker-registry.osc.edu/kubernetes/charts
+    repository: oci://docker-registry.osc.edu/kubernetes/charts
     #version: 1.54.0
     #repository: file://./ollama-helm

--- a/charts-private/ollama/Chart.yaml
+++ b/charts-private/ollama/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
   - name: zyou
 dependencies:
   - name: osc-common
-    version: 0.13.0
+    version: 0.14.0
     repository: https://osc.github.io/osc-helm-charts/
     # repository: file://../../charts/osc-common
   - name: ollama

--- a/charts-private/ollama/Chart.yaml
+++ b/charts-private/ollama/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: ollama
+description: OSC Ollama service for classroom
+type: application
+version: 0.1.0
+appVersion: '0.18.3'
+maintainers:
+  - name: zyou
+dependencies:
+  - name: osc-common
+    version: 0.13.0
+    repository: https://osc.github.io/osc-helm-charts/
+    # repository: file://../../charts/osc-common
+  - name: ollama
+    version: 1.54.0-osc-r1
+    repository: oci://docker-registry.osc.edu/kubernetes/charts
+    #version: 1.54.0
+    #repository: file://./ollama-helm

--- a/charts-private/ollama/ci/test-values.yaml
+++ b/charts-private/ollama/ci/test-values.yaml
@@ -1,0 +1,25 @@
+global:
+  environment: dev
+  imagePullSecret:
+    password: IMAGE-PULL-PASSWORD
+  nodeSelectorRole: test
+  debugGroups:
+    - foobar
+  maintenanceGroups:
+    - foo
+    - bar
+  project: PAS0710
+
+ollama:
+  image:
+    tag: '0.18.3'
+
+  persistentVolume:
+    accessModes:
+    - ReadWriteOnce
+    storageClass: standard
+
+  podSecurityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534

--- a/charts-private/ollama/ci/test-values.yaml
+++ b/charts-private/ollama/ci/test-values.yaml
@@ -11,9 +11,6 @@ global:
   project: PAS0710
 
 ollama:
-  image:
-    tag: '0.18.3'
-
   persistentVolume:
     accessModes:
     - ReadWriteOnce

--- a/charts-private/ollama/values.yaml
+++ b/charts-private/ollama/values.yaml
@@ -1,0 +1,139 @@
+global:
+  # -- The service account used by OSC deployments.
+  # Also pulled from global.env.<env>.serviceAccount
+  oscServiceAccount: '{{ include "ollama.name" . }}'
+  # -- The deployment's OSC environment
+  environment: production
+  # -- The nodeSelector role
+  nodeSelectorRole: webservices
+  imagePullSecret:
+    # -- Create the image pull secret
+    create: true
+    # -- imagePullSecret name
+    name: osc-registry
+    # -- imagePullSecret registry
+    registry: docker-registry.osc.edu
+    # -- imagePullSecret username
+    username: robot$webservices-read
+    # -- imagePullSecret password.
+    # This value will be set by OSC's Puppet.
+    # This value must be set to IMAGE-PULL-PASSWORD for CI tests.
+    password:
+  # @ignored
+  networkPolicy:
+    # -- Create the network policy
+    create: false
+    # -- Labels for NetworkPolicy podSelector. Defaults to `"osc.common.selectorLabels"`
+    podSelector: ~
+    # Example define podSelector labels
+    #  podSelector:
+    #    app.kubernetes.io/name: test
+    #
+    # -- Labels of pods allowed to Ingress from the same namespace
+    ingressAllowedPods: []
+    # Example additional ingress labels
+    #  ingressAllowedPods:
+    #    - require: test
+    #    - client: test
+    #
+    # @ignored
+    ingressNamespace: ingress-nginx
+    # @ignored
+    prometheusNamespace: prometheus
+  # @ignored
+  webservicesDeploy:
+    # -- Create webservices deployment rolebinding
+    create: false
+  # -- Groups that debug pods
+  debugGroups: []
+  # -- Groups that can perform maintenance operations
+  maintenanceGroups: []
+  # -- Groups that are allowed to perform port forwarding
+  portforwardGroups: []
+  auth:
+    # @ignored
+    enable: false
+    # @ignored
+    allowGroups: []
+  ingress:
+    # -- Ingress host
+    # @default -- **required**
+    host: ""
+    # -- Ingress host alias
+    # @default -- **required**
+    hostAlias: ""
+  alert:
+    # -- The alert receiver
+    receiver: sciapps
+  # -- The service project
+  # @default -- **required**
+  project: ''
+
+ollama:
+  networkPolicy:
+    # -- Array of additional pod labels to allow
+    allowedPodLabels: []
+
+  imagePullSecrets:
+  - name: osc-registry
+
+  image:
+    repository: docker-registry.osc.edu/kubernetes/ollama/ollama
+    tag: ''
+
+  ollama:
+    mountPath: /ollama
+    gpu:
+      enabled: true
+      type: nvidia
+      number: 1
+    models:
+      pull: []
+
+  nodeSelector:
+    nvidia.com/gpu.product: NVIDIA-A100-PCIE-40GB-MIG-1g.5gb
+
+  service:
+    annotations:
+      prometheus.io/probe_module: http
+      prometheus.io/probe_scheme: http
+
+  podSecurityContext:
+    runAsNonRoot: true
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    seccompProfile:
+      type: RuntimeDefault
+    privileged: false
+
+  resources:
+    limits:
+      memory: 8Gi
+      cpu: 4
+    requests:
+      memory: 4Gi
+      cpu: 2
+
+  extraEnv:
+  - name: OLLAMA_MODELS
+    value: /ollama
+  - name: HOME
+    value: /ollama
+  - name: OLLAMA_FLASH_ATTENTION
+    value: '1'
+
+  persistentVolume:
+    enabled: true
+    accessModes:
+    - ReadWriteMany
+    annotations:
+      osc.edu/fileset: '{{ .Values.global.project }}'
+    size : 500Gi
+    storageClass: local-scratch
+
+  serviceAccount:
+    create: false

--- a/charts-private/ollama/values.yaml
+++ b/charts-private/ollama/values.yaml
@@ -82,9 +82,6 @@ ollama:
     labels:
       '{{ include "osc.common.serviceAccountKey" . }}': '{{ include "osc.common.serviceAccountValue" . }}'
       receiver: '{{ .Values.global.alert.receiver }}'
-    
-    # -- Labels to add to the deployment
-    labels: {}
 
   # -- Docker registry secret names as an array
   imagePullSecrets:
@@ -160,7 +157,7 @@ ollama:
     - ReadWriteMany
     annotations:
       osc.edu/fileset: '{{ .Values.global.project }}'
-    size : 500Gi
+    size: 500Gi
     storageClass: local-ess
 
   serviceAccount:

--- a/charts-private/ollama/values.yaml
+++ b/charts-private/ollama/values.yaml
@@ -1,7 +1,7 @@
 global:
   # -- The service account used by OSC deployments.
   # Also pulled from global.env.<env>.serviceAccount
-  oscServiceAccount: '{{ include "ollama.name" . }}'
+  oscServiceAccount: '{{ include "ollama.fullname" . }}'
   # -- The deployment's OSC environment
   environment: production
   # -- The nodeSelector role
@@ -45,9 +45,11 @@ global:
     # -- Create webservices deployment rolebinding
     create: false
   # -- Groups that debug pods
-  debugGroups: []
+  debugGroups:
+    - sappstf
   # -- Groups that can perform maintenance operations
-  maintenanceGroups: []
+  maintenanceGroups:
+    - sappstf
   # -- Groups that are allowed to perform port forwarding
   portforwardGroups: []
   auth:
@@ -70,37 +72,62 @@ global:
   project: ''
 
 ollama:
-  networkPolicy:
-    # -- Array of additional pod labels to allow
-    allowedPodLabels: []
+  # -- Map of labels to add to the pods
+  podLabels:
+    '{{ include "osc.common.serviceAccountKey" . }}': '{{ tpl (include "osc.common.serviceAccountValue" .) . }}'
+    receiver: '{{ .Values.global.alert.receiver }}'
 
+  deployment:
+    # -- Labels to add to the deployment
+    labels:
+      '{{ include "osc.common.serviceAccountKey" . }}': '{{ include "osc.common.serviceAccountValue" . }}'
+      receiver: '{{ .Values.global.alert.receiver }}'
+    
+    # -- Labels to add to the deployment
+    labels: {}
+
+  # -- Docker registry secret names as an array
   imagePullSecrets:
-  - name: osc-registry
+  - name: '{{ .Values.global.imagePullSecret.name }}'
 
   image:
+    # -- Docker image registry
     repository: docker-registry.osc.edu/kubernetes/ollama/ollama
-    tag: ''
+    # -- Docker image tag, overrides the image tag whose default is the chart appVersion.
+    tag: '0.18.3'
 
   ollama:
     mountPath: /ollama
     gpu:
+      # -- Enable GPU integration
       enabled: true
       type: nvidia
+      # -- Specify the number of GPU
       number: 1
     models:
+      # -- List of models to pull at container startup
+      # The more you add, the longer the container will take to start if models are not present
       pull: []
 
+  # -- Node labels for pod assignment.
   nodeSelector:
     nvidia.com/gpu.product: NVIDIA-A100-PCIE-40GB-MIG-1g.5gb
+    '{{ include "osc.common.nodeSelectorRoleKey" . }}': ''
 
   service:
+    # -- Labels to add to the service
+    labels:
+      receiver: '{{ .Values.global.alert.receiver }}'
+    # -- Annotations to add to the service
     annotations:
       prometheus.io/probe_module: http
       prometheus.io/probe_scheme: http
 
+  # -- Pod Security Context
   podSecurityContext:
     runAsNonRoot: true
 
+  # -- Container Security Context
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -127,13 +154,15 @@ ollama:
     value: '1'
 
   persistentVolume:
+    # -- Enable persistence using PVC
     enabled: true
     accessModes:
     - ReadWriteMany
     annotations:
       osc.edu/fileset: '{{ .Values.global.project }}'
     size : 500Gi
-    storageClass: local-scratch
+    storageClass: local-ess
 
   serviceAccount:
-    create: false
+    # -- Specifies whether a service account should be created
+    create: true


### PR DESCRIPTION
* All data, including keys and models, are stored in the /ollama mount path using a PVC.
* Modified the annotation in the PVC template from the upstream repository (https://github.com/otwld/ollama-helm) to use tpl.