### PR TITLE
Remove kube-proxy scrape config

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus
 description: OSC Prometheus deployment
 type: application
-version: 0.19.1
+version: 0.20.0
 appVersion: "v2.44.0"
 maintainers:
   - name: treydock

--- a/charts/prometheus/templates/config.yaml
+++ b/charts/prometheus/templates/config.yaml
@@ -72,31 +72,6 @@ data:
         regex: default;kubernetes;https
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
-    - job_name: kubernetes-kube-proxy
-      scheme: http
-      metrics_path: /metrics
-      kubernetes_sd_configs:
-      - role: node
-      relabel_configs:
-      - source_labels: [__address__]
-        action: replace
-        target_label: __address__
-        regex: '([^:]+)(?::\d+)?'
-        replacement: '$1:10249'
-      - action: labelmap
-        regex: __meta_kubernetes_node_label_(.+)
-      - source_labels: [__meta_kubernetes_node_name]
-        regex: '(.+)'
-        replacement: '$1'
-        target_label: host
-      - source_labels: [host]
-        target_label: node
-      - regex: "feature_node_.+"
-        action: labeldrop
-      - regex: "nvidia_com_.+"
-        action: labeldrop
-      - regex: "cluster"
-        action: labeldrop
     - job_name: kubernetes-services
       scheme: http
       metrics_path: "/probe"


### PR DESCRIPTION
OSC is moving to eBPF where kube-proxy is no longer required