### PR TITLE
Support custom mount path

### DIFF
--- a/charts/cryosparc/Chart.yaml
+++ b/charts/cryosparc/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cryosparc
 description: OSC CryoSPARC bootstrap Helm Chart
 type: application
-version: 0.8.3
+version: 0.9.0
 appVersion: "4.7.1-r3"
 maintainers:
   - name: zyou

--- a/charts/cryosparc/README.md
+++ b/charts/cryosparc/README.md
@@ -1,6 +1,6 @@
 # cryosparc
 
-![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.7.1-r3](https://img.shields.io/badge/AppVersion-4.7.1--r3-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.7.1-r3](https://img.shields.io/badge/AppVersion-4.7.1--r3-informational?style=flat-square)
 
 OSC CryoSPARC bootstrap Helm Chart
 
@@ -75,6 +75,7 @@ admin:
 | image.pullPolicy |  | `"IfNotPresent"` |
 | mounts.home |  | `"/users/{{ tpl .Values.homeDir . }}/{{ tpl (include \"osc.common.serviceAccountValue\" .) . }}"` |
 | mounts.project |  | `"/fs/ess/{{ required \"Project must be provided\" .Values.global.project }}"` |
+| mounts.rwDir |  | `{}` |
 | admin.email |  | `""` |
 | admin.password |  | `""` |
 | nodeSelector |  | `{}` |

--- a/charts/cryosparc/templates/statefulset.yaml
+++ b/charts/cryosparc/templates/statefulset.yaml
@@ -94,6 +94,11 @@ spec:
           mountPath: {{ tpl .Values.mounts.project . }}
         - name: home
           mountPath: {{ tpl .Values.mounts.home . }}
+        {{- range $name, $path := .Values.mounts.rwDir }}
+        - name: {{ $name | lower }}
+          mountPath: {{ tpl $path . }}
+          readOnly: false
+        {{- end }}
         - name: munge-socket
           mountPath: /var/run/munge/munge.socket.2
         - name: slurm-conf
@@ -150,6 +155,12 @@ spec:
         hostPath:
           path: {{ tpl .Values.mounts.project . }}
           type: Directory
+      {{- range $name, $path := .Values.mounts.rwDir }}
+      - name: {{ $name | lower }}
+        hostPath:
+          path: {{ tpl $path . }}
+          type: Directory
+      {{- end }}
       - name: munge-socket
         hostPath:
           path: /var/run/munge/munge.socket.2

--- a/charts/cryosparc/values.yaml
+++ b/charts/cryosparc/values.yaml
@@ -123,6 +123,7 @@ image:
 mounts:
   home: /users/{{ tpl .Values.homeDir . }}/{{ tpl (include "osc.common.serviceAccountValue" .) . }}
   project: /fs/ess/{{ required "Project must be provided" .Values.global.project }}
+  rwDir: {}
 
 admin:
   email: ''


### PR DESCRIPTION
Several CryoSPARC services require access to external project directories, so I defined the `rwDir` parameter to configure custom mount paths.

In the controller data, I think we can configure it as follows:
```
cryosciapps:
  rw_dir:
    PZS0530: "/fs/ess/PZS0530"
    PAS1234: "/fs/ess/PAS1234"
 ```
Then Puppet handle this data structure as a Hash?