### PR TITLE
Add portfix step for migration from source with different port

### DIFF
--- a/charts/cryosparc/Chart.yaml
+++ b/charts/cryosparc/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cryosparc
 description: OSC CryoSPARC bootstrap Helm Chart
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "4.7.1-r3"
 maintainers:
   - name: zyou

--- a/charts/cryosparc/README.md
+++ b/charts/cryosparc/README.md
@@ -1,6 +1,6 @@
 # cryosparc
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.7.1-r3](https://img.shields.io/badge/AppVersion-4.7.1--r3-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.7.1-r3](https://img.shields.io/badge/AppVersion-4.7.1--r3-informational?style=flat-square)
 
 OSC CryoSPARC bootstrap Helm Chart
 

--- a/charts/cryosparc/templates/_helpers.tpl
+++ b/charts/cryosparc/templates/_helpers.tpl
@@ -154,6 +154,10 @@ Defined here so that version changes in labels of the configmap won't automatica
 */}}
 {{- define "cryosparc.run.content" -}}
 export CRYOSPARC_MASTER_HOSTNAME="${MY_NODE_NAME}"
+cryosparcm start database
+cryosparcm database fixport
+cryosparcm stop
+sleep 5
 set -e
 echo "Create cryosparc directory"
 mkdir -p {{ tpl .Values.mounts.home . }}/.cryosparc

--- a/charts/cryosparc/templates/statefulset.yaml
+++ b/charts/cryosparc/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ['cryosparcm', 'stop']   # Fix rollout restart issue
+              command: ['sh', '-c', 'cryosparcm', 'stop']   # Fix rollout restart issue
         workingDir: /opt/cryosparc_master
         env:
         - name: TZ


### PR DESCRIPTION
CryoSPARC fails to import data from another cluster if the basePort is configured differently. The fix is to run `cryosparcm database fixport` before starting the service.