### PR TITLE
Add scratch for service account project

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -161,6 +161,8 @@ jobs:
           sudo mkdir -p /var/lib/sss/pipes /etc/sssd
           sudo mkdir -p /fs/ess
           sudo install -d -o 65534 -g 65534 -m 0750 /fs/ess/PAS0710
+          sudo mkdir -p /fs/scratch
+          sudo install -d -o 65534 -g 65534 -m 0750 /fs/scratch/PAS0710
           sudo mkdir -p /users/PAS0710
           sudo install -d -o 65534 -g 65534 -m 0700 /users/PAS0710/cryosciapps
       - name: Add namespaces

--- a/charts/cryosparc/Chart.yaml
+++ b/charts/cryosparc/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cryosparc
 description: OSC CryoSPARC bootstrap Helm Chart
 type: application
-version: 0.9.3
+version: 0.10.0
 appVersion: "4.7.1-r3"
 maintainers:
   - name: zyou

--- a/charts/cryosparc/README.md
+++ b/charts/cryosparc/README.md
@@ -1,6 +1,6 @@
 # cryosparc
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.7.1-r3](https://img.shields.io/badge/AppVersion-4.7.1--r3-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.7.1-r3](https://img.shields.io/badge/AppVersion-4.7.1--r3-informational?style=flat-square)
 
 OSC CryoSPARC bootstrap Helm Chart
 
@@ -75,6 +75,7 @@ admin:
 | image.pullPolicy |  | `"IfNotPresent"` |
 | mounts.home |  | `"/users/{{ tpl .Values.homeDir . }}/{{ tpl (include \"osc.common.serviceAccountValue\" .) . }}"` |
 | mounts.project |  | `"/fs/ess/{{ required \"Project must be provided\" .Values.global.project }}"` |
+| mounts.scratch |  | `"/fs/scratch/{{ required \"Project must be provided\" .Values.global.project }}"` |
 | mounts.rwDir |  | `{}` |
 | admin.email |  | `""` |
 | admin.password |  | `""` |

--- a/charts/cryosparc/templates/statefulset.yaml
+++ b/charts/cryosparc/templates/statefulset.yaml
@@ -92,6 +92,8 @@ spec:
           mountPath: /cryosparc_data
         - name: project
           mountPath: {{ tpl .Values.mounts.project . }}
+        - name: scratch
+          mountPath: {{ tpl .Values.mounts.scratch . }}
         - name: home
           mountPath: {{ tpl .Values.mounts.home . }}
         {{- range $name, $path := .Values.mounts.rwDir }}
@@ -154,6 +156,10 @@ spec:
       - name: project
         hostPath:
           path: {{ tpl .Values.mounts.project . }}
+          type: Directory
+      - name: scratch
+        hostPath:
+          path: {{ tpl .Values.mounts.scratch . }}
           type: Directory
       {{- range $name, $path := .Values.mounts.rwDir }}
       - name: {{ $name | lower }}

--- a/charts/cryosparc/values.yaml
+++ b/charts/cryosparc/values.yaml
@@ -123,6 +123,7 @@ image:
 mounts:
   home: /users/{{ tpl .Values.homeDir . }}/{{ tpl (include "osc.common.serviceAccountValue" .) . }}
   project: /fs/ess/{{ required "Project must be provided" .Values.global.project }}
+  scratch: /fs/scratch/{{ required "Project must be provided" .Values.global.project }}
   rwDir: {}
 
 admin:


### PR DESCRIPTION
Some users of the web08 CryoSPARC services set their project directories in /fs/scratch. Mount the /fs/scratch directory for the service account project.